### PR TITLE
add .gitignore and pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+pfb_lola_seq.egg-info/
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools"]
+
+[project]
+version = "0.0.0"
+name = "pfb_lola_seq"
+requires-python=">= 3.8"
+readme = "README.md"
+dependencies = [
+    "black",
+    "flake8",
+    "isort",
+]
+
+[tool.black]
+line-length = 115
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+
+  # The following are specific to Black, you probably don't want those.
+  | blib2to3
+  | tests/data
+)/
+'''


### PR DESCRIPTION
This PR proposes two new files:
  + .gitignore - a list of file patterns that git should ignore
  + pyproject.toml - project metadata used by pip